### PR TITLE
fix: resolve allOf composition validation errors (#42)

### DIFF
--- a/schema/FoodAndBeverageOffer/v2.1/attributes.yaml
+++ b/schema/FoodAndBeverageOffer/v2.1/attributes.yaml
@@ -12,7 +12,7 @@ components:
   schemas:
     FoodAndBeverageOfferAttributes:
       type: object
-      additionalProperties: false
+      unevaluatedProperties: false
       x-beckn-container: offerAttributes
       x-jsonld:
         "@context": "https://schema.beckn.io/FoodAndBeverageOffer/v2.1/context.jsonld"

--- a/schema/FoodAndBeverageResource/v2.1/attributes.yaml
+++ b/schema/FoodAndBeverageResource/v2.1/attributes.yaml
@@ -14,7 +14,7 @@ components:
   schemas:
     FoodAndBeverageResourceAttributes:
       type: object
-      additionalProperties: false
+      unevaluatedProperties: false
       x-beckn-container: resourceAttributes
       x-jsonld:
         "@context": "https://schema.beckn.io/FoodAndBeverageResource/v2.1/context.jsonld"

--- a/schema/GroceryResource/v2.1/attributes.yaml
+++ b/schema/GroceryResource/v2.1/attributes.yaml
@@ -12,7 +12,7 @@ components:
   schemas:
     GroceryResourceAttributes:
       type: object
-      additionalProperties: false
+      unevaluatedProperties: false
       x-beckn-container: resourceAttributes
       x-jsonld:
         "@context": "https://schema.beckn.io/GroceryResource/v2.1/context.jsonld"

--- a/schema/HomeAndKitchenResource/v2.1/attributes.yaml
+++ b/schema/HomeAndKitchenResource/v2.1/attributes.yaml
@@ -12,7 +12,7 @@ components:
   schemas:
     HomeAndKitchenResourceAttributes:
       type: object
-      additionalProperties: false
+      unevaluatedProperties: false
       x-beckn-container: resourceAttributes
       x-jsonld:
         "@context": "https://schema.beckn.io/HomeAndKitchenResource/v2.1/context.jsonld"

--- a/schema/RetailOffer/v2.1/attributes.yaml
+++ b/schema/RetailOffer/v2.1/attributes.yaml
@@ -11,7 +11,7 @@ components:
   schemas:
     RetailOffer:
       type: object
-      additionalProperties: false
+      unevaluatedProperties: false
       x-beckn-container: offerAttributes
       x-jsonld:
         "@context": "https://schema.beckn.io/RetailOffer/v2.1/context.jsonld"

--- a/schema/RetailResource/v2.1/attributes.yaml
+++ b/schema/RetailResource/v2.1/attributes.yaml
@@ -11,7 +11,7 @@ components:
   schemas:
     RetailResource:
       type: object
-      additionalProperties: false
+      unevaluatedProperties: false
       x-beckn-container: resourceAttributes
       x-jsonld:
         "@context": "https://schema.beckn.io/RetailResource/v2.1/context.jsonld"


### PR DESCRIPTION
## Summary

- Replaces `additionalProperties: false` with `unevaluatedProperties: false` at the top-level of all schemas that are composed via `allOf`
- Fixes validation errors like `must NOT have additional properties 'nutrition'` on child schemas that extend a parent via `allOf`
- Nested sub-object constraints (e.g. `identity`, `physical`, `dimensions`) are unchanged — they are not `allOf`-composed and remain correct

## Root Cause

`additionalProperties: false` only evaluates properties declared in the **same schema object's** `properties` keyword. It has no awareness of properties introduced by `allOf`, `anyOf`, or `$ref` siblings. This causes both the parent (`RetailResource`) and child (`GroceryResourceAttributes` etc.) to reject properties that are valid per the composed schema.

`unevaluatedProperties: false` (JSON Schema 2020-12 / OpenAPI 3.1) is composition-aware and considers all properties evaluated across `allOf` branches — the correct keyword for this pattern.

## Files Changed

| File | Schema |
|------|--------|
| `schema/RetailResource/v2.1/attributes.yaml` | `RetailResource` |
| `schema/RetailOffer/v2.1/attributes.yaml` | `RetailOffer` |
| `schema/GroceryResource/v2.1/attributes.yaml` | `GroceryResourceAttributes` |
| `schema/FoodAndBeverageResource/v2.1/attributes.yaml` | `FoodAndBeverageResourceAttributes` |
| `schema/HomeAndKitchenResource/v2.1/attributes.yaml` | `HomeAndKitchenResourceAttributes` |
| `schema/FoodAndBeverageOffer/v2.1/attributes.yaml` | `FoodAndBeverageOfferAttributes` |

## Notes

kin-openapi v0.137.0 (used in beckn-onix) parses `unevaluatedProperties` but does not enforce it at runtime yet. Strict unknown-property validation can be revisited when upstream adds support.

Closes #42