### PR TITLE
fix: update CDS discover endpoint to new IP

### DIFF
--- a/testnet/retail-devkit/config/local-simple-routing-BAPCaller.yaml
+++ b/testnet/retail-devkit/config/local-simple-routing-BAPCaller.yaml
@@ -11,6 +11,6 @@ routingRules:
   - version: "2.0.0"
     targetType: "url"
     target:
-      url: "https://34.14.221.66.sslip.io/beckn"
+      url: "https://34.93.165.42.sslip.io/beckn"
     endpoints:
       - discover


### PR DESCRIPTION
Updated the Discover service URL in testnet/retail-devkit/config/local-simple-routing-BAPCaller.yaml. Old IP 34.14.221.66 is no longer serving the CDS correctly. Changed to 34.93.165.42.