### PR TITLE
fix(RetailOffer/v2.1): remove orphaned addOns/addOnItems context terms

### DIFF
--- a/schema/RetailOffer/v2.1/context.jsonld
+++ b/schema/RetailOffer/v2.1/context.jsonld
@@ -29,12 +29,6 @@
     "acceptedPaymentMethod": {
       "@id": "rcoa:acceptedPaymentMethod"
     },
-    "addOns": {
-      "@id": "rcoa:addOns"
-    },
-    "addOnItems": {
-      "@id": "rcoa:addOnItems"
-    },
     "policies": {
       "@id": "rcoa:policies"
     },


### PR DESCRIPTION
## Description
Completes the cleanup from c2749a9 ("removed the addOns as duplicate with core offer").

That commit removed `addOns` and `addOnItems` from `attributes.yaml` but left the corresponding `rcoa:addOns` and `rcoa:addOnItems` mappings in `context.jsonld`, creating two dangling terms with no matching `x-jsonld-id`, no `vocab.jsonld` definition, and no example references.

Add-ons are handled on the core `beckn:Offer` via `offerAttributes`; duplicating them at the RetailOffer level was redundant. This change removes those two blocks, bringing context terms and attribute `x-jsonld-id`s into exact one-to-one correspondence — consistent with every other balanced object in the schema.

**Changed file:** `schema/RetailOffer/v2.1/context.jsonld`

Closes #60
