### PR TITLE
fix: update devkit config to sync with starter-kit (#62)

### DIFF
--- a/testnet/retail-devkit/config/local-simple-bap.yaml
+++ b/testnet/retail-devkit/config/local-simple-bap.yaml
@@ -68,10 +68,16 @@ modules:
           id: router
           config:
             routingConfig: ./config/local-simple-routing-BAPReceiver.yaml
+        payloadStore:
+          id: payloadstore
+          config:
+            ttl: "24h"
+            indexTTL: "25h"
+            storeSignature: "true"
         middleware:
           - id: reqpreprocessor
             config:
-              uuidKeys: transaction_id,message_id
+              contextKeys: transactionId,messageId
               role: bap
       steps:
         - validateSign
@@ -139,7 +145,7 @@ modules:
         middleware:
           - id: reqpreprocessor
             config:
-              uuidKeys: transaction_id,message_id
+              contextKeys: transactionId,messageId
               role: bap
       steps:
         - addRoute

--- a/testnet/retail-devkit/config/local-simple-bpp.yaml
+++ b/testnet/retail-devkit/config/local-simple-bpp.yaml
@@ -68,6 +68,17 @@ modules:
           id: router
           config:
             routingConfig: ./config/local-simple-routing-BPPReceiver.yaml
+        payloadStore:
+          id: payloadstore
+          config:
+            ttl: "24h"
+            indexTTL: "25h"
+            storeSignature: "true"
+        middleware:
+          - id: reqpreprocessor
+            config:
+              contextKeys: transactionId,messageId
+              role: bpp
       steps:
         - validateSign
         - addRoute
@@ -134,7 +145,7 @@ modules:
         middleware:
           - id: reqpreprocessor
             config:
-              uuidKeys: transaction_id,message_id
+              contextKeys: transactionId,messageId
               role: bpp
       steps:
         - addRoute


### PR DESCRIPTION
## Summary

- Rename `uuidKeys` → `contextKeys` (with camelCase values `transactionId,messageId`) in the `reqpreprocessor` middleware across all four modules (`bapTxnReceiver`, `bapTxnCaller`, `bppTxnReceiver`, `bppTxnCaller`) — this is the root cause fix for the `subscriberID not set` error in the `signAck` step
- Add `payloadStore` plugin to `bapTxnReceiver` and `bppTxnReceiver` to match starter-kit config

## Problem

ONIX logs were showing:
```
{"level":"error","error":"subscriberID not set","module_id":"bppTxnReceiver","message":"Response step signAck failed"}
```

The `uuidKeys` field in the `reqpreprocessor` middleware was renamed to `contextKeys` in a recent ONIX update. The old field was silently ignored, so context keys (including `subscriberID`) were never injected into the request pipeline, causing `signAck` to fail.

## Test plan

- [ ] Restart onix-bap and onix-bpp containers with updated config
- [ ] Send a `select` request through the BAP and verify no `subscriberID not set` error in ONIX logs
- [ ] Confirm `signAck` completes successfully for both BAP and BPP receiver modules

Closes #62